### PR TITLE
added the possibility to retrieve the Client

### DIFF
--- a/lib/HireVoice/Neo4j/EntityManager.php
+++ b/lib/HireVoice/Neo4j/EntityManager.php
@@ -396,7 +396,7 @@ class EntityManager
         $this->proxyFactory = $factory;
     }
 
-    protected function getClient()
+    public function getClient()
     {
         return $this->client();
     }


### PR DESCRIPTION
Hi,

I'm implementing your lib into a symfony application. I have a graph manager that is extending the EntityManager.

At this time, as all the class properties are private, there is no possibility to get the Client when extending your entity manager so I've added a getClient function.

It is useful to test the connection at the application bootstrap.

Thanks
