### PR TITLE
Better indexing

### DIFF
--- a/lib/HireVoice/Neo4j/EntityManager.php
+++ b/lib/HireVoice/Neo4j/EntityManager.php
@@ -473,6 +473,7 @@ class EntityManager
         }
 		
 		$index->add($node, 'class', $class);
+		$index->add($node, 'id', $entity->getId());
     }
 
     private function writeIndexes()


### PR DESCRIPTION
try to run this query before and after the patch:

```
START root=node:`HireVoice\Neo4j\Tests\Entity\Movie`("id:*") 
RETURN root
```

before it will return nothing, after 26 nodes after running test on clean db.
