### PR TITLE
Instantiate proxy classes without using constructor.

### DIFF
--- a/lib/HireVoice/Neo4j/Meta/Entity.php
+++ b/lib/HireVoice/Neo4j/Meta/Entity.php
@@ -101,6 +101,9 @@ class Entity
         return $this->indexedProperties;
     }
 
+    /**
+     * @return \HireVoice\Neo4j\Meta\Property[]
+     */
     function getProperties()
     {
         return $this->properties;
@@ -121,6 +124,12 @@ class Entity
         return $this->manyToOneRelations;
     }
 
+    /**
+     * Finds property by $name.
+     *
+     * @param string $name
+     * @return \HireVoice\Neo4j\Meta\Property|null
+     */
     function findProperty($name)
     {
         $property = Reflection::getProperty($name);

--- a/lib/HireVoice/Neo4j/Meta/Property.php
+++ b/lib/HireVoice/Neo4j/Meta/Property.php
@@ -158,6 +158,11 @@ class Property
         return $this->name;
     }
 
+    function getOriginalName()
+    {
+        return $this->property->getName();
+    }
+
     function matches($names)
     {
         foreach (func_get_args() as $name) {

--- a/lib/HireVoice/Neo4j/Proxy/Factory.php
+++ b/lib/HireVoice/Neo4j/Proxy/Factory.php
@@ -24,7 +24,9 @@
 namespace HireVoice\Neo4j\Proxy;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use HireVoice\Neo4j\Extension\ArrayCollection as ExtendedArrayCollection;
 use HireVoice\Neo4j\Exception;
+use HireVoice\Neo4j\Meta\Entity as Meta;
 
 class Factory
 {
@@ -70,13 +72,34 @@ class Factory
         return $proxy;
     }
 
-    private function createProxy($meta)
+    private function initializeProperties($object, Meta $meta)
+    {
+        $reflection = new \ReflectionObject($object);
+
+        foreach ($meta->getManyToManyRelations() as $metaProperty) {
+            /* @var $metaProperty \HireVoice\Neo4j\Meta\Property */
+            if ($property = $reflection->getProperty($metaProperty->getOriginalName())) {
+                if (!$property->isPublic()) {
+                    $property->setAccessible(true);
+                }
+                $property->setValue($object, new ExtendedArrayCollection); // maybe it would be better idea to get
+                                                                           // property from $meta directly?
+                if (!$property->isPublic()) {
+                    $property->setAccessible(false);
+                }
+            }
+        }
+
+        return $object;
+    }
+
+    private function createProxy(Meta $meta)
     {
         $proxyClass = $meta->getProxyClass();
         $className = $meta->getName();
 
         if (class_exists($proxyClass, false)) {
-            return $this->newInstance($proxyClass);
+            return $this->initializeProperties($this->newInstance($proxyClass), $meta);
         }
 
         $targetFile = "{$this->proxyDir}/$proxyClass.php";
@@ -219,7 +242,7 @@ CONTENT;
         }
 
         require $targetFile;
-        return $this->newInstance($proxyClass);
+        return $this->initializeProperties($this->newInstance($proxyClass), $meta);
     }
 
     private function newInstance($proxyClass)


### PR DESCRIPTION
It removes requirement of "all parameters of constructor must be optional", thus making OGM more transparent for end-user.

Its the same thing that Doctrine devs did.
http://www.doctrine-project.org/jira/browse/DDC-79
