### PR TITLE
Added support for "array" format on properties.

### DIFF
--- a/lib/HireVoice/Neo4j/Meta/Property.php
+++ b/lib/HireVoice/Neo4j/Meta/Property.php
@@ -2,7 +2,7 @@
 /**
  * Copyright (C) 2012 Louis-Philippe Huberdeau
  *
- * Permission is hereby granted, free of charge, to any person obtaining a 
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -30,7 +30,7 @@ class Property
     const INDEX = 'HireVoice\\Neo4j\\Annotation\\Index';
     const TO_MANY = 'HireVoice\\Neo4j\\Annotation\\ManyToMany';
     const TO_ONE = 'HireVoice\\Neo4j\\Annotation\\ManyToOne';
-    
+
     private $reader;
     private $property;
     private $name;
@@ -42,7 +42,12 @@ class Property
     {
         $this->reader = $reader;
         $this->property = $property;
-        $this->name = Reflection::cleanProperty($property->getName());
+        if ($this->isProperty() || $this->isRelation()) {
+            $this->name = $property->getName();
+        } else {
+            // as far as we know only relation list are collections with names we can 'normalize'
+            $this->name = Reflection::singularizeProperty($property->getName());
+        }
         $property->setAccessible(true);
     }
 
@@ -89,7 +94,7 @@ class Property
 
         return false;
     }
-    
+
     function isRelationList()
     {
         if ($annotation = $this->reader->getPropertyAnnotation($this->property, self::TO_MANY)) {
@@ -118,6 +123,8 @@ class Property
         case 'scalar':
         case 'relation':
             return $raw;
+        case 'array':
+            return serialize($raw);
         case 'json':
             return json_encode($raw);
         case 'date':
@@ -137,6 +144,9 @@ class Property
         case 'scalar':
         case 'relation':
             $this->property->setValue($entity, $value);
+            break;
+        case 'array':
+            $this->property->setValue($entity, unserialize($value));
             break;
         case 'json':
             $this->property->setValue($entity, json_decode($value, true));
@@ -163,7 +173,7 @@ class Property
         foreach (func_get_args() as $name) {
             if (0 === strcasecmp($name, $this->name)
                 || 0 === strcasecmp($name, $this->property->getName())
-                || 0 === strcasecmp($name, Reflection::cleanProperty($this->property->getName()))
+                || 0 === strcasecmp($name, Reflection::singularizeProperty($this->property->getName()))
             ) {
                 return true;
             }

--- a/lib/HireVoice/Neo4j/Meta/Reflection.php
+++ b/lib/HireVoice/Neo4j/Meta/Reflection.php
@@ -28,10 +28,10 @@ class Reflection
     public static function getProperty($methodName)
     {
         $property = substr($methodName, 3);
-        return self::cleanProperty($property);
+        return self::singularizeProperty($property);
     }
 
-    public static function cleanProperty($property)
+    public static function singularizeProperty($property)
     {
         $property = lcfirst($property);
 

--- a/lib/HireVoice/Neo4j/Repository.php
+++ b/lib/HireVoice/Neo4j/Repository.php
@@ -132,7 +132,7 @@ class Repository
     {
         if (strpos($name, 'findOneBy') === 0) {
             $property = substr($name, 9);
-            $property = Meta\Reflection::cleanProperty($property);
+            $property = Meta\Reflection::singularizeProperty($property);
 
             if ($node = $this->getIndex()->findOne($property, $arguments[0])) {
                 return $this->entityManager->load($node);
@@ -152,10 +152,10 @@ class Repository
 
     private function getSearchableProperty($property)
     {
-        $property = Meta\Reflection::cleanProperty($property);
+        $property = Meta\Reflection::singularizeProperty($property);
 
         foreach ($this->meta->getIndexedProperties() as $p) {
-            if (Meta\Reflection::cleanProperty($p->getName()) == $property) {
+            if (Meta\Reflection::singularizeProperty($p->getName()) == $property) {
                 return $property;
             }
         }

--- a/lib/HireVoice/Neo4j/Tests/Entity/Movie.php
+++ b/lib/HireVoice/Neo4j/Tests/Entity/Movie.php
@@ -42,6 +42,11 @@ class Movie
     protected $title;
 
     /**
+     * @OGM\Property(format="array")
+     */
+    protected $alternateTitles;
+
+    /**
      * @OGM\Property
      */
     protected $category;
@@ -79,6 +84,7 @@ class Movie
 
     function __construct()
     {
+        $this->alternateTitles = array();
         $this->actors = new ArrayCollection;
         $this->cinemas = new ArrayCollection;
         $this->movieRegistryCode = uniqid();
@@ -192,6 +198,24 @@ class Movie
     function getCategory()
     {
         return $this->category;
+    }
+
+    public function setAlternateTitles(array $alternateTitles)
+    {
+        $this->alternateTitles = array();
+        foreach ($alternateTitles as $alternateTitle) {
+            $this->addAlternateTitle($alternateTitle);
+        }
+    }
+
+    public function addAlternateTitle($alternateTitle)
+    {
+        $this->alternateTitles[] = $alternateTitle;
+    }
+
+    public function getAlternateTitles()
+    {
+        return $this->alternateTitles;
     }
 }
 

--- a/lib/HireVoice/Neo4j/Tests/EntityManagerTest.php
+++ b/lib/HireVoice/Neo4j/Tests/EntityManagerTest.php
@@ -390,7 +390,10 @@ class EntityManagerTest extends TestCase
     function testStoreArray()
     {
         $movie = new Entity\Movie;
-        $movie->setTitle(array('A', 'B'));
+        $movie->setTitle('The Lord of the Rings: The Fellowship of the Ring');
+
+        $movie->addAlternateTitle('LOTR: The Fellowship of the Ring');
+        $movie->addAlternateTitle('The Fellowship of the Ring');
 
         $em = $this->getEntityManager();
         $em->persist($movie);
@@ -398,7 +401,7 @@ class EntityManagerTest extends TestCase
 
         $movie = $em->findAny($movie->getId());
 
-        $this->assertEquals(array('A', 'B'), $movie->getTitle());
+        $this->assertEquals(array('LOTR: The Fellowship of the Ring', 'The Fellowship of the Ring'), $movie->getAlternateTitles());
     }
 
     function testStoreStructure()
@@ -424,14 +427,22 @@ class EntityManagerTest extends TestCase
         $em->flush();
 
         $movie = $em->findAny($movie->getId());
-        $movie->addTitle('World');
+        $movie->addTitle('Die Hard');
 
         $em = $this->getEntityManager();
         $em->persist($movie);
         $em->flush();
 
         $movie = $em->findAny($movie->getId());
-        $this->assertEquals('World', $movie->getTitle());
+        $this->assertEquals('Die Hard', $movie->getTitle());
+
+        $movie->addTitle(' with a Vengance');
+        $em = $this->getEntityManager();
+        $em->persist($movie);
+        $em->flush();
+
+        $movie = $em->findAny($movie->getId());
+        $this->assertEquals('Die Hard with a Vengance', $movie->getTitle());
     }
 
     function testEntityRetrievedIsTheSame()

--- a/lib/HireVoice/Neo4j/Tests/EntityMetaTest.php
+++ b/lib/HireVoice/Neo4j/Tests/EntityMetaTest.php
@@ -49,7 +49,7 @@ class EntityMetaTest extends \PHPUnit_Framework_TestCase
             $names[] = $property->getName();
         }
 
-        $this->assertEquals(array('title', 'category', 'releaseDate', 'movieRegistryCode', 'blob'), $names);
+        $this->assertEquals(array('title', 'alternateTitles', 'category', 'releaseDate', 'movieRegistryCode', 'blob'), $names);
     }
 
     function testManyToMany()

--- a/lib/HireVoice/Neo4j/Tests/ReflectionTest.php
+++ b/lib/HireVoice/Neo4j/Tests/ReflectionTest.php
@@ -28,17 +28,17 @@ class ReflectionTest extends \PHPUnit_Framework_TestCase
 {
     function testBasicPlural()
     {
-        $this->assertEquals('bee', Reflection::cleanProperty('bees'));
+        $this->assertEquals('bee', Reflection::singularizeProperty('bees'));
     }
 
     function testWithIes()
     {
-        $this->assertEquals('property', Reflection::cleanProperty('properties'));
+        $this->assertEquals('property', Reflection::singularizeProperty('properties'));
     }
 
     function testDoubleS()
     {
-        $this->assertEquals('access', Reflection::cleanProperty('access'));
+        $this->assertEquals('access', Reflection::singularizeProperty('access'));
     }
 }
 


### PR DESCRIPTION
Properties marked with this format are serialized to database.

Although storing arrays is possible with "json" format, I think "array" format is a much needed addendum. Especially knowing that deserialization is faster than decoding json (which is useful in system dealing with much more reads than writes, which means majority of systems out there). 

Also I had to address one problem I've found, particularly forcing every property meta-name into its singular form. 
