### PR TITLE
Add support for unique indexes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.2.0,<2.3.0",
+        "doctrine/common": ">=2.2.0,<2.4.0",
         "everyman/neo4jphp": "*"
     },
     "minimum-stability": "dev",

--- a/lib/HireVoice/Neo4j/Annotation/Index.php
+++ b/lib/HireVoice/Neo4j/Annotation/Index.php
@@ -29,5 +29,9 @@ namespace HireVoice\Neo4j\Annotation;
  */
 class Index
 {
+    /**
+     * @var boolean
+     */
+    public $unique = false;
 }
 

--- a/lib/HireVoice/Neo4j/EntityManager.php
+++ b/lib/HireVoice/Neo4j/EntityManager.php
@@ -557,16 +557,13 @@ class EntityManager
 
         $class = $meta->getName();
         $index = $this->getRepository($class)->getIndex();
-        
-		$class = $meta->getName();
-		$index = $this->getRepository($class)->getIndex();
-		$node = $this->getLoadedNode($entity);
-		
+        $node = $this->getLoadedNode($entity);
+
         foreach ($meta->getIndexedProperties() as $property) {
-            $index->add($node, $property->getName(), $property->getValue($entity));
+            $index->add($node, $property->getName(), $property->getValue($entity), $property->isUnique());
         }
-		
-		$index->add($node, 'id', $entity->getId());
+
+        $index->add($node, 'id', $entity->getId(), true);
     }
 
     private function writeIndexes()

--- a/lib/HireVoice/Neo4j/Meta/Property.php
+++ b/lib/HireVoice/Neo4j/Meta/Property.php
@@ -66,6 +66,15 @@ class Property
         return !! $this->reader->getPropertyAnnotation($this->property, self::INDEX);
     }
 
+    function isUnique()
+    {
+        if ($annotation = $this->reader->getPropertyAnnotation($this->property, self::INDEX)) {
+            return $annotation->unique;
+        }
+
+        return false;
+    }
+
     function isTraversed()
     {
         return $this->traversed;

--- a/lib/HireVoice/Neo4j/Repository.php
+++ b/lib/HireVoice/Neo4j/Repository.php
@@ -81,7 +81,10 @@ class Repository
     {
         if (! $this->index) {
             $this->index = $this->entityManager->createIndex($this->class);
-            $this->index->save();
+
+            // Disabled this because it generates an unnecessary request.
+            // The server creates new indexes automatically
+            //$this->index->save();
         }
 
         return $this->index;
@@ -90,7 +93,9 @@ class Repository
     function writeIndex()
     {
         if ($this->index) {
-            $this->index->save();
+            // Disabled this because it generates an unnecessary request.
+            // The server creates new indexes automatically
+            //$this->index->save();
         }
     }
     /**


### PR DESCRIPTION
This implements support for unique indexes, using annotations.

Example:

``` php
/*
 * @var string
 *
 * @OGM\Property
 * @OGM\Index(unique=true)
 */
protected $email;
```

For this to work, the neo4jphp module must also be updated to support unique indexes. I have submitted code for that here: https://github.com/jadell/neo4jphp/pull/66

The result is that two entities of the same class with the same `email` property value (in this example) cannot be entered into the index.
