### PR TITLE
Make proxy objects serializable

### DIFF
--- a/lib/HireVoice/Neo4j/Proxy/Entity.php
+++ b/lib/HireVoice/Neo4j/Proxy/Entity.php
@@ -23,7 +23,9 @@
 
 namespace HireVoice\Neo4j\Proxy;
 
-interface Entity
+use Doctrine\Common\Persistence\Proxy as BaseProxy;
+
+interface Entity extends BaseProxy
 {
     function getEntity();
 

--- a/lib/HireVoice/Neo4j/Proxy/Factory.php
+++ b/lib/HireVoice/Neo4j/Proxy/Factory.php
@@ -122,6 +122,7 @@ class $proxyClass extends $className implements HireVoice\\Neo4j\\Proxy\\Entity
     private \$neo4j_node;
     private \$neo4j_loadCallback;
     private \$neo4j_relationships = false;
+    private \$neo4j_initialized = false;
 
     function getEntity()
     {
@@ -164,7 +165,17 @@ class $proxyClass extends $className implements HireVoice\\Neo4j\\Proxy\\Entity
         \$this->neo4j_loadCallback = \$loadCallback;
     }
 
-    private function __load(\$name, \$propertyName)
+    public function __load()
+    {
+        \$this->neo4j_initialized = true;
+    }
+
+    public function __isInitialized()
+    {
+        return \$this->neo4j_initialized;
+    }
+
+    private function __loadProperty(\$name, \$propertyName)
     {
         if (in_array(\$propertyName, \$this->neo4j_hydrated)) {
             return;
@@ -299,7 +310,7 @@ CONTENT;
 
     function {$method->getName()}($arguments)
     {
-        self::__load($name, $propertyName);
+        self::__loadProperty($name, $propertyName);
         return parent::{$method->getName()}($parts);
     }
 


### PR DESCRIPTION
When trying to serialize OGM results (proxy objects) with JMS Serializer, I got:

```
Resources are not supported in serialized data. Path: Everyman\\Neo4j\\Transport\\Curl -> Everyman\\Neo4j\\Client -> Everyman\\Neo4j\\Node -> neo4jProxyMyProxy -> Doctrine\\Common\\Collections\\ArrayCollection
```

JMS Serializer’s [DoctrineProxySubscriber](https://github.com/schmittjoh/serializer/blob/master/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php) takes care of serializing Doctrine proxies, but didn't act on the OGM's proxies because they don't implement the `Doctrine\Common\Persistence\Proxy` interface. This PR fixes that, so OGM proxies will be serialized correctly.
