### PR TITLE
Parameter processing

### DIFF
--- a/lib/HireVoice/Neo4j/Query/ParameterProcessor.php
+++ b/lib/HireVoice/Neo4j/Query/ParameterProcessor.php
@@ -67,17 +67,12 @@ class ParameterProcessor
             $key = key($parameters);
             next($parameters);
 
-            if (is_numeric($value)) {
-                $string = str_replace(":$key", $value, $string);
-                return false;
+            if ($mode == 'cypher') {
+                $string = str_replace(":$key", '{' . $key . '}', $string);
             } else {
-                if ($mode == 'cypher') {
-                    $string = str_replace(":$key", '{' . $key . '}', $string);
-                } else {
-                    $string = str_replace(":$key", $key, $string);
-                }
-                return true;
+                $string = str_replace(":$key", $key, $string);
             }
+            return true;
         });
         $string = str_replace('[;;', '[:', $string);
 

--- a/lib/HireVoice/Neo4j/Tests/EntityManagerTest.php
+++ b/lib/HireVoice/Neo4j/Tests/EntityManagerTest.php
@@ -425,8 +425,12 @@ class EntityManagerTest extends TestCase
            ->set('movie', $movie)
            ->getOne();
 
+        $expectedParams = array(
+            'movie' => $movie->getId()
+        );
+
         $this->assertInstanceOf('Everyman\Neo4j\Cypher\Query', $queryObj);
-        $this->assertEmpty($paramsArray);
+        $this->assertEquals($expectedParams, $paramsArray);
         $this->assertGreaterThan(0, $timeElapsed);
     }
 


### PR DESCRIPTION
Is there a reason why [numeric parameters](https://github.com/lphuberdeau/Neo4j-PHP-OGM/blob/master/lib/HireVoice/Neo4j/Query/ParameterProcessor.php#L70) are not handled as named parameters?

As I understand the [docs](http://docs.neo4j.org/chunked/milestone/cypher-parameters.html#_node_id) say they can be used instead of id's and are also encouraged.

Is there something more to it, or can it be changed?
