### PR TITLE
fix hydrating properties that evaluate to false

### DIFF
--- a/lib/HireVoice/Neo4j/Proxy/Factory.php
+++ b/lib/HireVoice/Neo4j/Proxy/Factory.php
@@ -57,7 +57,7 @@ class Factory
         foreach ($meta->getProperties() as $property) {
             $name = $property->getName();
 
-            if ($value = $node->getProperty($name)) {
+            if (null !== $value = $node->getProperty($name)) {
                 $property->setValue($proxy, $value);
                 $proxy->__addHydrated($name);
             }


### PR DESCRIPTION
This commit fixes hydrating properties that [evaluate to false](http://www.php.net/manual/en/language.types.boolean.php).

I am not sure in empty strings, but in my understanding only null values shouldn't be set explicitly. Correct my if I am wrong and I will make changes accordingly.
