### PR TITLE
Update composer.json to more relaxed ~2.4 version dependency for doctrine/common as it uses semantic versioning and API is not broken

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.2.0,<2.4.0-dev",
+        "doctrine/common": ">=2.2.0,~2.4",
         "everyman/neo4jphp": "*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Tested, it works with current ~2.4 stable version.
