### PR TITLE
Update to dependency doctrine/common needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.2.0,<2.5.0-dev",
+        "doctrine/common": ">=2.2.0,<2.6.0-dev",
         "everyman/neo4jphp": "*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Dependency resolution is broken when using doctrine/orm dev-master with hirevoice/neo4jphp-ogm dev-master.
Since this commit doctrine/doctrine2@ce4df761dfc6412f0e7666307573af5f042a4354, doctrine/common need to be >=2.5.x-dev.
I ran the test suite locally, and all test are passing with this version.
